### PR TITLE
Fix muted opponent vocals with no ghost tapping

### DIFF
--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -710,6 +710,9 @@ class PlayState extends MusicBeatState {
         #if ENGINE_SCRIPTING
         hxsCall("onOpponentNoteHold", [note]);
         #end
+
+        if (music.voices.length == 1)
+            music.playerVolume = 1;
     }
 
     public function onMiss(note:Note):Void {

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -659,6 +659,9 @@ class PlayState extends MusicBeatState {
         #if ENGINE_SCRIPTING
         hxsCall("onOpponentNoteHit", [note]);
         #end
+
+        if (music.voices.length == 1)
+            music.playerVolume = 1;
     }
 
     public function onBotplayNoteHit(note:Note):Void {


### PR DESCRIPTION
Previously if you missed a note with ghost tapping turned off while the opponent was singing it would mute their vocals:

https://github.com/Sword352/FNF-EternalEngine/assets/47027981/dfe3d8ca-b6b5-442e-9e00-72536078af79

 This PR just unmutes the vocals on opponent note hit

